### PR TITLE
Switch Astro output to static and comment out adapter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,9 +40,9 @@ export default defineConfig({
         },
     },
 
-    output: 'server', integrations: [sitemap()],
+    output: 'static', integrations: [sitemap()],
 
-    adapter: node({
+    /*adapter: node({
         mode: 'standalone'
-    })
+    })*/
 });


### PR DESCRIPTION
Changed the Astro config output from 'server' to 'static' and commented out the Node adapter configuration. This prepares the project for static site generation instead of server-side rendering.