### PR TITLE
Refactor Astro config and set prerender to false for API routes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,4 @@
-import {defineConfig} from 'astro/config';
-
+import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import autoprefixer from 'autoprefixer';
 import dotenv from 'dotenv';
@@ -7,42 +6,39 @@ import node from '@astrojs/node';
 
 dotenv.config();
 
-// https://astro.build/config
 export default defineConfig({
-    site: 'https://testing.ftcturbov8.com', base: "/", trailingSlash: "ignore",
+    site: 'https://testing.ftcturbov8.com',
+    base: '/',
+    trailingSlash: 'ignore',
 
     build: {
-        inlineStylesheets: 'never'
+        inlineStylesheets: 'never', // keep external styles
+        assets: 'client',           // optional, but clarifies intent
+        rollupOptions: {
+            output: {
+                assetFileNames: (assetInfo) => {
+                    const original = assetInfo.name ?? '';
 
-    },
+                    if (original.endsWith('.css')) {
+                        return 'assets/style-[hash][extname]';
+                    }
 
-    vite: {
-        css: {
-            postcss: {
-                plugins: [autoprefixer()]
-            }
-        }, build: {
-            rollupOptions: {
-                output: {
-                    assetFileNames: (assetInfo) => {
-                        const original = assetInfo.names?.[0] ?? '';
-
-                        if (original.endsWith('.css')) {
-                            // All CSS → assets/style.css (or style2.css etc. if duplicated)
-                            return 'assets/style-[hash][extname]';
-                        }
-
-                        // Fallback for other assets
-                        return 'assets/[name]-[hash][extname]';
-                    },
+                    return 'assets/[name]-[hash][extname]';
                 },
             },
         },
     },
 
-     integrations: [sitemap()],
+    vite: {
+        css: {
+            postcss: {
+                plugins: [autoprefixer()],
+            },
+        },
+    },
 
-    /*adapter: node({
-        mode: 'standalone'
-    })*/
+    integrations: [sitemap()],
+    adapter: node({
+        mode: 'standalone',
+    }),
 });

--- a/src/pages/api/submit.ts
+++ b/src/pages/api/submit.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-
+export const prerender = false;
 export const POST: APIRoute = async ({ request }) => {
     const formData = await request.formData();
     const name = formData.get("name");

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,5 +1,5 @@
 import type {APIRoute} from 'astro';
-
+export const prerender = false;
 const getRobotsTxt = (sitemapURL: URL) => `User-agent: *
 Allow: /
 


### PR DESCRIPTION
Cleaned up astro.config.mjs formatting, clarified build and asset output options, and enabled standalone node adapter. Set `prerender = false` in API and robots.txt endpoints to prevent static generation.