### PR TITLE
Use npm caching with github workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
       - run: npm ci --verbose
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml.disabled
+++ b/.github/workflows/firebase-hosting-pull-request.yml.disabled
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
       - run: npm ci --verbose
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
Updated both merge and pull request Firebase Hosting workflows to use actions/setup-node@v4 with Node.js version 22 and npm caching. This ensures consistent Node.js environment and improved dependency management during CI runs.