### PR TITLE
Remove verbose flag from npm ci in workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-      - run: npm ci --verbose
+      - run: npm ci
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml.disabled
+++ b/.github/workflows/firebase-hosting-pull-request.yml.disabled
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-      - run: npm ci --verbose
+      - run: npm ci
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The --verbose flag was removed from the npm ci command in both firebase-hosting-merge and firebase-hosting-pull-request workflows to simplify output.