### PR TITLE
Embed Google Form, comment out custom form

### DIFF
--- a/src/pages/apply.astro
+++ b/src/pages/apply.astro
@@ -148,6 +148,18 @@ import Button from "../components/Button.astro";
                     <div class="col-12">
                         <h2 class="section-title text-center mb-4">Application Form</h2>
                         <div class="application-form-container">
+                            <div class="google-form-wrapper">
+                                <iframe
+                                    src="https://docs.google.com/forms/d/e/1FAIpQLSeteDo6Ipj8jLucW8R612JNuHCZybcOvvTpuyGF3k1KD4T5Jw/viewform?embedded=true"
+                                    width="100%"
+                                    height="2746"
+                                    frameborder="0"
+                                    marginheight="0"
+                                    marginwidth="0">Loading…</iframe>
+                            </div>
+                        </div>
+                        <!-- Original custom form commented out
+                        <div class="application-form-container">
                             <form id="application-form" class="application-form" novalidate>
                                 <div class="form-group" style="color: var(--light-red)">* Indicates required question
                                 </div>
@@ -170,7 +182,6 @@ import Button from "../components/Button.astro";
                                         <label for="phone">Phone Number</label>
                                         <input type="tel" id="phone" autocomplete="tel" name="phone">
                                     </div>
-
                                 </div>
                                 <div class="form-group">
                                     <label for="parentEmail">Parent/Guardian Email *</label>
@@ -235,7 +246,6 @@ import Button from "../components/Button.astro";
                                 </div>
                                 <div class="center-flex">
                                     <div class="captcha-wrapper">
-                                        <!--<div class="h-captcha" data-captcha="true"></div>-->
                                         <div class="g-recaptcha" data-theme="dark"
                                              data-sitekey="6Le185wrAAAAAFhel_aoTssK915nRuBYlr_gYZCz"></div>
                                     </div>
@@ -244,6 +254,7 @@ import Button from "../components/Button.astro";
                                 </div>
                             </form>
                         </div>
+                        -->
                     </div>
                 </div>
 
@@ -251,8 +262,9 @@ import Button from "../components/Button.astro";
             </div>
         </section>
     </main>
-    <script src="https://www.google.com/recaptcha/api.js" async defer/>
-    <script src="../scripts/applyForm.ts"/>
+    <!-- reCAPTCHA and applyForm scripts removed (using Google Form iframe instead) -->
+    <!-- <script src="https://www.google.com/recaptcha/api.js" async defer/> -->
+    <!-- <script src="../scripts/applyForm.ts"/> -->
 </Layout>
 
 <style>


### PR DESCRIPTION
Replace the in-page application form with an embedded Google Form iframe and leave the original custom form commented out for reference. Removed/disabled the local applyForm.ts script and the reCAPTCHA script tags since submissions are now handled via the Google Form. This simplifies submission handling and preserves the old implementation if we need to revert or extract fields later.